### PR TITLE
fix a bug where launching another dev server with a port that is being used throws an unhandled exception

### DIFF
--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -4,6 +4,7 @@ var config  = require('../config');
 var http    = require('http');
 var express = require('express');
 var gulp    = require('gulp');
+var gutil   = require('gulp-util');
 var morgan  = require('morgan');
 
 gulp.task('server', function() {
@@ -19,9 +20,14 @@ gulp.task('server', function() {
   });
 
   // Start webserver if not already running
-  if ( !global.serverRunning ) {
-    http.createServer(server).listen(config.serverport, function () {
-      global.serverRunning = true;
-    });
-  }
+  var s = http.createServer(server);
+  s.on('error', function(err){
+    if(err.code === 'EADDRINUSE'){
+      gutil.log('Development server is already started at port ' + config.serverport);
+    }
+    else {
+      throw err;
+    }
+  });
+  s.listen(config.serverport);
 });


### PR DESCRIPTION
You can reproduce the bug if you run `gulp dev` and then `gulp protractor`, an unhandled exception is thrown which basically says the port is already being used. A better way to handle it is to catch the error, and keep the script running since it is an expected error.
