### PR TITLE
Add source map support.

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -34,7 +34,8 @@ module.exports = {
 
   'browserify': {
     'entries'   : ['./app/js/main.js'],
-    'bundleName': 'main.js'
+    'bundleName': 'main.js',
+    'sourcemap' : true,
   },
 
   'test': {

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -5,6 +5,8 @@ var gulp         = require('gulp');
 var gulpif       = require('gulp-if');
 var gutil        = require('gulp-util');
 var source       = require('vinyl-source-stream');
+var sourcemaps   = require('gulp-sourcemaps');
+var buffer       = require('vinyl-buffer');
 var streamify    = require('gulp-streamify');
 var watchify     = require('watchify');
 var browserify   = require('browserify');
@@ -39,11 +41,15 @@ function buildScript(file) {
 
     gutil.log('Rebundle...');
 
+    var createSourcemap = global.isProd && config.browserify.sourcemap;
     return stream.on('error', handleErrors)
       .pipe(source(file))
+      .pipe(gulpif(createSourcemap, buffer()))
+      .pipe(gulpif(createSourcemap, sourcemaps.init()))
       .pipe(gulpif(global.isProd, streamify(uglify({
         compress: { drop_console: true }
       }))))
+      .pipe(gulpif(createSourcemap, sourcemaps.write('./')))
       .pipe(gulp.dest(config.scripts.dest))
       .pipe(browserSync.reload({ stream: true, once: true }));
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
+    "gulp-sourcemaps": "^1.3.0",
     "imagemin-pngcrush": "^0.1.0",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.21",
@@ -69,6 +70,7 @@
     "tiny-lr": "0.0.9",
     "uglifyify": "^2.5.0",
     "vinyl-source-stream": "^0.1.1",
+    "vinyl-buffer": "^1.0.0",
     "watchify": "^2.0.0"
   },
   "browserify": {


### PR DESCRIPTION
Source maps are generated by default with `gulp prod`. They can be disabled
by setting `config.browserify.sourcemap` to false.