### PR TITLE
Pre-compress assets with gzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Just as there is the `gulp dev` task for development, there is also a `gulp prod
 
 **Reminder:** When running the production task, gulp will not fire up the express server and serve your index.html. This task is designed to be run before the `deploy` step that may copy the files from `/build` to a production web server.
 
+#### Pre-compressing text assets
+
+When running with `gulp prod`, a pre-compressed file is generated in addition to uncompressed file (.html.gz, .js.gz, css.js). This is done to enable web servers serve compressed content without having to compress it on the fly. Pre-compression is handled by `gzip` task.
+
 ##### Testing
 
 A Gulp tasks also exists for running the test framework (discussed in detail below). Running `gulp test` will run any and all tests inside the `/test` directory and show the results (and any errors) in the terminal.

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -28,6 +28,12 @@ module.exports = {
     'dest': 'app/js'
   },
 
+  'gzip': {
+    'src': 'build/**/*.{html,xml,json,css,js,js.map}',
+    'dest': 'build/',
+    'options': {}
+  },
+
   'dist': {
     'root'  : 'build'
   },

--- a/gulp/tasks/gzip.js
+++ b/gulp/tasks/gzip.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var gulp   = require('gulp');
+var gzip   = require('gulp-gzip');
+var config = require('../config');
+
+gulp.task('gzip', function() {
+
+  return gulp.src(config.gzip.src)
+    .pipe(gzip(config.gzip.options))
+    .pipe(gulp.dest(config.gzip.dest));
+
+});

--- a/gulp/tasks/production.js
+++ b/gulp/tasks/production.js
@@ -9,6 +9,6 @@ gulp.task('prod', ['clean'], function(cb) {
 
   global.isProd = true;
 
-  runSequence('styles', 'images', 'views', 'browserify', cb);
+  runSequence('styles', 'images', 'views', 'browserify', 'gzip', cb);
 
 });

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "gulp-sourcemaps": "^1.3.0",
+    "gulp-gzip": "^0.0.8",
     "imagemin-pngcrush": "^0.1.0",
     "jshint-stylish": "^1.0.0",
     "karma": "^0.12.21",


### PR DESCRIPTION
Pre-compress assets with gzip, so that web server can serve without compressing.

Adds `gzip` task to `gulp prod`. See
http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html and
http://www.lemoda.net/mod_rewrite/gzip-static/index.html