### PR TITLE
Add missing require

### DIFF
--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -3,6 +3,7 @@
 var config      = require('../config');
 var changed     = require('gulp-changed');
 var gulp        = require('gulp');
+var gulpif      = require('gulp-if');
 var browserSync = require('browser-sync');
 
 gulp.task('fonts', function() {


### PR DESCRIPTION
The Gulp `font` task was missing a require, this adds it in.