### PR TITLE
Add global.buildType when run `gulp dev` and `gulp prod`. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A boilerplate using AngularJS, SASS, Gulp, and Browserify that also utilizes [th
 
 Now that `gulp dev` is running, the server is up as well and serving files from the `/build` directory. Any changes in the `/app` directory will be automatically processed by Gulp and the changes will be injected to any open browsers pointed at the proxy address.
 
+### Options
+
+By set `global.buildType`, you can save the build result in `/build/${global.buildType}` directory.
+
 ---
 
 This boilerplate uses the latest versions of the following libraries:

--- a/app/index.html
+++ b/app/index.html
@@ -8,12 +8,16 @@
       <meta name="description" content="">
       <meta name="viewport" content="width=device-width">
 
+      <!-- build:css -->
       <link rel="stylesheet" href="css/main.css">
+      <!-- endbuild -->
   </head>
   <body>
 
       <div ui-view></div>
 
+      <!-- build:js -->
       <script src="js/main.js"></script>
+      <!-- endbuild -->
   </body>
 </html>

--- a/app/js/constants.js
+++ b/app/js/constants.js
@@ -2,7 +2,7 @@
 
 var AppSettings = {
   appTitle: 'Example Application',
-  apiUrl: '/api/v1'
+  apiUrl: process.env.BUILD_TYPE === 'development' ? '/dev/api/v1' : '/prod/api/v1'
 };
 
 module.exports = AppSettings;

--- a/app/js/controllers/example.js
+++ b/app/js/controllers/example.js
@@ -5,7 +5,7 @@ var controllersModule = require('./_index');
 /**
  * @ngInject
  */
-function ExampleCtrl() {
+controllersModule.controller('ExampleCtrl', function () {
 
   // ViewModel
   var vm = this;
@@ -13,6 +13,4 @@ function ExampleCtrl() {
   vm.title = 'AngularJS, Gulp, and Browserify!';
   vm.number = 1234;
 
-}
-
-controllersModule.controller('ExampleCtrl', ExampleCtrl);
+});

--- a/app/js/directives/example.js
+++ b/app/js/directives/example.js
@@ -5,7 +5,7 @@ var directivesModule = require('./_index.js');
 /**
  * @ngInject
  */
-function exampleDirective() {
+directivesModule.directive('exampleDirective', function () {
 
   return {
     restrict: 'EA',
@@ -16,6 +16,4 @@ function exampleDirective() {
     }
   };
 
-}
-
-directivesModule.directive('exampleDirective', exampleDirective);
+});

--- a/app/js/on_run.js
+++ b/app/js/on_run.js
@@ -15,6 +15,7 @@ function OnRun($rootScope, AppSettings) {
     }
 
     $rootScope.pageTitle += AppSettings.appTitle;
+    $rootScope.apiUrl = AppSettings.apiUrl;
   });
 
 }

--- a/app/js/services/example.js
+++ b/app/js/services/example.js
@@ -5,7 +5,7 @@ var servicesModule = require('./_index.js');
 /**
  * @ngInject
  */
-function ExampleService($q, $http) {
+servicesModule.service('ExampleService', function($q, $http) {
 
   var service = {};
 
@@ -13,9 +13,9 @@ function ExampleService($q, $http) {
     var deferred = $q.defer();
 
     $http.get('apiPath').success(function(data) {
-        deferred.resolve(data);
+      deferred.resolve(data);
     }).error(function(err, status) {
-        deferred.reject(err, status);
+      deferred.reject(err, status);
     });
 
     return deferred.promise;
@@ -23,6 +23,4 @@ function ExampleService($q, $http) {
 
   return service;
 
-}
-
-servicesModule.service('ExampleService', ExampleService);
+});

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -1,7 +1,7 @@
 <h1 class="heading -large">{{ home.title }}</h1>
 
 <h3 class="heading -medium">Here is a fancy number served up courtesy of Angular: <span class="number-example">{{ home.number }}</span></h3>
-
+<p>api url: {{apiUrl}}</p>
 <img src="images/angular.png" height="100" />
 <img src="images/gulp.png" height="100" />
 <img src="images/browserify.png" height="100" />

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,27 +1,44 @@
 'use strict';
 
+var path = require('path');
+
+function buildPath(subDir) {
+  return function () {
+    var paths = ['build'];
+    if (global.buildType) {
+      paths.push(global.buildType);
+    }
+
+    if (subDir) {
+      paths.push(subDir);
+    }
+
+    return path.join.apply(path, paths);
+  };
+}
+
 module.exports = {
 
   'serverport': 3000,
 
   'styles': {
     'src' : 'app/styles/**/*.scss',
-    'dest': 'build/css'
+    'dest': buildPath('css')
   },
 
   'scripts': {
     'src' : 'app/js/**/*.js',
-    'dest': 'build/js'
+    'dest': buildPath('js')
   },
 
   'images': {
     'src' : 'app/images/**/*',
-    'dest': 'build/images'
+    'dest': buildPath('images')
   },
 
   'fonts': {
     'src' : ['app/fonts/**/*'],
-    'dest': 'build/fonts'
+    'dest': buildPath('fonts')
   },
 
   'views': {
@@ -35,12 +52,12 @@ module.exports = {
 
   'gzip': {
     'src': 'build/**/*.{html,xml,json,css,js,js.map}',
-    'dest': 'build/',
+    'dest': buildPath(),
     'options': {}
   },
 
   'dist': {
-    'root'  : 'build'
+    'root'  : buildPath()
   },
 
   'browserify': {

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -16,6 +16,7 @@ var handleErrors = require('../util/handleErrors');
 var browserSync  = require('browser-sync');
 var debowerify   = require('debowerify');
 var ngAnnotate   = require('browserify-ngannotate');
+var envify       = require('envify/custom');
 
 // Based on: http://blog.avisi.nl/2014/04/25/how-to-keep-a-fast-build-with-browserify-and-reactjs/
 function buildScript(file) {
@@ -38,6 +39,9 @@ function buildScript(file) {
   bundler.transform(babelify);
   bundler.transform(debowerify);
   bundler.transform(ngAnnotate);
+  bundler.transform(envify({
+    BUILD_TYPE: global.buildType
+  }));
   bundler.transform('brfs');
 
   function rebundle() {

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -64,6 +64,10 @@ function buildScript(file) {
 
 gulp.task('browserify', function() {
 
+  if (global.isProd) {
+    return buildScript("main-" + global.buildTime + ".js");
+  }
+
   return buildScript('main.js');
 
 });

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -54,7 +54,7 @@ function buildScript(file) {
         compress: { drop_console: true }
       }))))
       .pipe(gulpif(createSourcemap, sourcemaps.write('./')))
-      .pipe(gulp.dest(config.scripts.dest))
+      .pipe(gulp.dest(config.scripts.dest()))
       .pipe(gulpif(browserSync.active, browserSync.reload({ stream: true, once: true })));
   }
 

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -6,6 +6,6 @@ var del    = require('del');
 
 gulp.task('clean', function(cb) {
 
-  del([config.dist.root], cb);
+  del([config.dist.root()], cb);
 
 });

--- a/gulp/tasks/development.js
+++ b/gulp/tasks/development.js
@@ -3,12 +3,13 @@
 var gulp        = require('gulp');
 var runSequence = require('run-sequence');
 
-gulp.task('dev', ['clean'], function(cb) {
+gulp.task('dev', [], function(cb) {
 
   cb = cb || function() {};
 
   global.isProd = false;
+  global.buildType = 'development';
 
-  runSequence(['styles', 'images', 'fonts', 'views', 'browserify'], 'watch', cb);
+  runSequence('clean', ['styles', 'images', 'fonts', 'views', 'browserify'], 'watch', cb);
 
 });

--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -9,8 +9,8 @@ var browserSync = require('browser-sync');
 gulp.task('fonts', function() {
 
   return gulp.src(config.fonts.src)
-    .pipe(changed(config.fonts.dest)) // Ignore unchanged files
-    .pipe(gulp.dest(config.fonts.dest))
+    .pipe(changed(config.fonts.dest())) // Ignore unchanged files
+    .pipe(gulp.dest(config.fonts.dest()))
     .pipe(gulpif(browserSync.active, browserSync.reload({ stream: true, once: true })));
 
 });

--- a/gulp/tasks/gzip.js
+++ b/gulp/tasks/gzip.js
@@ -8,6 +8,6 @@ gulp.task('gzip', function() {
 
   return gulp.src(config.gzip.src)
     .pipe(gzip(config.gzip.options))
-    .pipe(gulp.dest(config.gzip.dest));
+    .pipe(gulp.dest(config.gzip.dest()));
 
 });

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -10,9 +10,9 @@ var browserSync = require('browser-sync');
 gulp.task('images', function() {
 
   return gulp.src(config.images.src)
-    .pipe(changed(config.images.dest)) // Ignore unchanged files
+    .pipe(changed(config.images.dest())) // Ignore unchanged files
     .pipe(gulpif(global.isProd, imagemin())) // Optimize
-    .pipe(gulp.dest(config.images.dest))
+    .pipe(gulp.dest(config.images.dest()))
     .pipe(gulpif(browserSync.active, browserSync.reload({ stream: true, once: true })));
 
 });

--- a/gulp/tasks/production.js
+++ b/gulp/tasks/production.js
@@ -3,12 +3,13 @@
 var gulp        = require('gulp');
 var runSequence = require('run-sequence');
 
-gulp.task('prod', ['clean'], function(cb) {
+gulp.task('prod', [], function(cb) {
 
   cb = cb || function() {};
 
   global.isProd = true;
+  global.buildType = 'production';
 
-  runSequence(['styles', 'images', 'fonts', 'views', 'browserify'], 'gzip', cb);
+  runSequence('clean', ['styles', 'images', 'fonts', 'views', 'browserify'], 'gzip', cb);
 
 });

--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -13,11 +13,11 @@ gulp.task('server', function() {
 
   // log all requests to the console
   server.use(morgan('dev'));
-  server.use(express.static(config.dist.root));
+  server.use(express.static(config.dist.root()));
 
   // Serve index.html for all routes to leave routing up to Angular
   server.all('/*', function(req, res) {
-      res.sendFile('index.html', { root: 'build' });
+      res.sendFile('index.html', { root: config.dist.root() });
   });
 
   // Start webserver if not already running

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -7,6 +7,7 @@ var gulpif       = require('gulp-if');
 var handleErrors = require('../util/handleErrors');
 var browserSync  = require('browser-sync');
 var autoprefixer = require('gulp-autoprefixer');
+var rename =       require('gulp-rename');
 
 gulp.task('styles', function () {
 
@@ -18,6 +19,11 @@ gulp.task('styles', function () {
     }))
     .pipe(autoprefixer("last 2 versions", "> 1%", "ie 8"))
     .on('error', handleErrors)
+    .pipe(gulpif(global.isProd, rename(function (path) {
+      path.dirname += "";
+      path.basename += "-" + global.buildTime;
+      path.extname += '';
+    })))
     .pipe(gulp.dest(config.styles.dest()))
     .pipe(gulpif(browserSync.active, browserSync.reload({ stream: true })));
 

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -18,7 +18,7 @@ gulp.task('styles', function () {
     }))
     .pipe(autoprefixer("last 2 versions", "> 1%", "ie 8"))
     .on('error', handleErrors)
-    .pipe(gulp.dest(config.styles.dest))
+    .pipe(gulp.dest(config.styles.dest()))
     .pipe(gulpif(browserSync.active, browserSync.reload({ stream: true })));
 
 });

--- a/gulp/tasks/views.js
+++ b/gulp/tasks/views.js
@@ -9,7 +9,7 @@ gulp.task('views', function() {
 
   // Put our index.html in the dist folder
   gulp.src('app/index.html')
-    .pipe(gulp.dest(config.dist.root));
+    .pipe(gulp.dest(config.dist.root()));
 
   // Process any other view files from app/views
   return gulp.src(config.views.src)

--- a/gulp/tasks/views.js
+++ b/gulp/tasks/views.js
@@ -2,13 +2,19 @@
 
 var config         = require('../config');
 var gulp           = require('gulp');
+var gulpif         = require('gulp-if');
 var templateCache  = require('gulp-angular-templatecache');
+var htmlreplace    = require('gulp-html-replace');
 
 // Views task
 gulp.task('views', function() {
 
   // Put our index.html in the dist folder
   gulp.src('app/index.html')
+    .pipe(gulpif(global.isProd, htmlreplace({
+      css: '/css/main-' + global.buildTime + '.css',
+      js: '/js/main-' + global.buildTime + '.js'
+    })))
     .pipe(gulp.dest(config.dist.root()));
 
   // Process any other view files from app/views

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,4 @@
  * To add a new task, simply add a new task file to gulp/tasks.
  */
 
-global.isProd = false;
-
 require('./gulp');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,4 +11,6 @@
  * To add a new task, simply add a new task file to gulp/tasks.
  */
 
+global.buildTime = +new Date();
+
 require('./gulp');

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-autoprefixer": "^2.0.0",
     "gulp-changed": "^1.0.0",
     "gulp-gzip": "^0.0.8",
+    "gulp-html-replace": "^1.4.4",
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^1.1.0",
     "gulp-jshint": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "browserify-shim": "^3.8.0",
     "debowerify": "^1.2.0",
     "del": "^0.1.3",
+    "envify": "^3.4.0",
     "express": "^4.7.2",
     "gulp": "^3.8.8",
     "gulp-angular-templatecache": "^1.3.0",


### PR DESCRIPTION
It is easy to add more build types, and build the results in different build dirs.
Sometimes I want to build more than one for different stages, dev, beta, gamma, prod, they use different configs.