### PR TITLE
Implement bulk-require, to make _index.js files less work to maintain

### DIFF
--- a/app/js/controllers/_index.js
+++ b/app/js/controllers/_index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var angular = require('angular');
+var bulk = require('bulk-require');
 
 module.exports = angular.module('app.controllers', []);
 
-// Define the list of controllers here
-require('./example.js');
+bulk(__dirname, ['./**/!(*_index|*.spec).js']);

--- a/app/js/directives/_index.js
+++ b/app/js/directives/_index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var angular = require('angular');
+var bulk = require('bulk-require');
 
 module.exports = angular.module('app.directives', []);
 
-// Define the list of directives here
-require('./example.js');
+bulk(__dirname, ['./**/!(*_index|*.spec).js']);

--- a/app/js/services/_index.js
+++ b/app/js/services/_index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var angular = require('angular');
+var bulk = require('bulk-require');
 
 module.exports = angular.module('app.services', []);
 
-// Define the list of services here
-require('./example.js');
+bulk(__dirname, ['./**/!(*_index|*.spec).js']);

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -35,10 +35,17 @@ function buildScript(file) {
     });
   }
 
-  bundler.transform(babelify);
-  bundler.transform(debowerify);
-  bundler.transform(ngAnnotate);
-  bundler.transform('brfs');
+  var transforms = [
+    babelify,
+    debowerify,
+    ngAnnotate,
+    'brfs',
+    'bulkify'
+  ];
+
+  transforms.forEach(function(transform) {
+    bundler.transform(transform);
+  });
 
   function rebundle() {
     var stream = bundler.bundle();

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "browserify-istanbul": "^0.2.0",
     "browserify-ngannotate": "^0.1.0",
     "browserify-shim": "^3.8.0",
+    "bulk-require": "^0.2.1",
+    "bulkify": "^1.1.1",
     "debowerify": "^1.2.0",
     "del": "^0.1.3",
     "express": "^4.7.2",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function(config) {
 
     browserify: {
       debug: true,
-      transform: ['browserify-shim', istanbul({
+      transform: ['browserify-shim', 'bulkify', istanbul({
         ignore: ['**/node_modules/**', '**/test/**'],
       })],
     },


### PR DESCRIPTION
Hey!

To start with, thank you for your work on this seed project. I used it a few months ago to get comfortable with Browserify, and it was a great jumping point.

This PR eliminates a "moving part" in the app (manually adding to the `_index.js` files). I've added bulk-require, and the bulkify transform (written by Substack).

Now, if you add any non-test JS files to the controllers/directives/services directories, they'll automatically be require()'d when someone require()'s your `_index.js` file.