### PR TITLE
Remove $ from non-injected, positional arguments in example directive

### DIFF
--- a/app/js/directives/example.js
+++ b/app/js/directives/example.js
@@ -9,8 +9,8 @@ function exampleDirective() {
 
   return {
     restrict: 'EA',
-    link: function($scope, $element) {
-      $element.on('click', function() {
+    link: function(scope, element) {
+      element.on('click', function() {
         console.log('element clicked');
       });
     }


### PR DESCRIPTION
PR changes `$scope` to `scope`, and `$element` to `element` in the example directive, to make it clearer that they are positional parameters, rather than being injected by Angular's DI mechanism.

https://thinkster.io/egghead/scope-vs-scope
http://www.bennadel.com/blog/2716-when-to-use-scope-vs-scope-in-angularjs.htm