### PR TITLE
Upgrade to the latest angular, and drop browserify-shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "browserify": "^5.10.0",
     "browserify-istanbul": "^0.2.0",
     "browserify-ngannotate": "^0.1.0",
-    "browserify-shim": "^3.8.0",
     "bulk-require": "^0.2.1",
     "bulkify": "^1.1.1",
     "debowerify": "^1.2.0",
@@ -81,17 +80,6 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^0.1.1",
     "watchify": "^2.0.0"
-  },
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
-  },
-  "browser": {
-    "angular": "./node_modules/angular/angular.js"
-  },
-  "browserify-shim": {
-    "angular": "angular"
   },
   "scripts": {
     "pretest": "npm install",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "node": ">=0.12.x"
   },
   "devDependencies": {
-    "angular": "^1.2.19",
-    "angular-mocks": "^1.2.22",
-    "angular-ui-router": "^0.2.10",
+    "angular": "^1.3.15",
+    "angular-mocks": "^1.3.15",
+    "angular-ui-router": "^0.2.13",
     "babelify": "^5.0.4",
     "brfs": "^1.2.0",
     "browser-sync": "^1.5.8",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -20,7 +20,6 @@ module.exports = function(config) {
     browserify: {
       debug: true,
       transform: [
-        'browserify-shim',
         'bulkify',
         istanbul({
           instrumenter: isparta,


### PR DESCRIPTION
This PR updates `angular`, `angular-mocks`, and `angular-ui-router` to their latest stable versions.

It also removes `browserify-shim`, which is no longer necessary since the [*instantaneous-browserification*](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#1314-instantaneous-browserification-2015-02-24) release of AngularJS, which now packages it as a CommonJS module (hooray!).