### PR TITLE
Renaming routes.js into on_config.js because it's the config phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The AngularJS files are all located within `/app/js`, structured in the followin
 constants.js  (any constant values that you want to make available to Angular)
 main.js       (the main file read by Browserify, also where the application is defined and bootstrapped)
 on_run.js     (any functions or logic that need to be executed on app.run)
-routes.js     (all route definitions and logic)
+on_config.js  (all route definitions and any logic that need to be executed on app.config)
 templates.js  (this is created via Gulp by compiling your views, and will not be present beforehand)
 ```
 

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -25,7 +25,7 @@ angular.element(document).ready(function() {
 
   angular.module('app').constant('AppSettings', require('./constants'));
 
-  angular.module('app').config(require('./routes'));
+  angular.module('app').config(require('./on_config'));
 
   angular.module('app').run(require('./on_run'));
 

--- a/app/js/on_config.js
+++ b/app/js/on_config.js
@@ -3,7 +3,7 @@
 /**
  * @ngInject
  */
-function Routes($stateProvider, $locationProvider, $urlRouterProvider) {
+function OnConfig($stateProvider, $locationProvider, $urlRouterProvider) {
 
   $locationProvider.html5Mode(true);
 
@@ -19,4 +19,4 @@ function Routes($stateProvider, $locationProvider, $urlRouterProvider) {
 
 }
 
-module.exports = Routes;
+module.exports = OnConfig;


### PR DESCRIPTION
I think it's a little cleaner to rename the config phase into a some more descriptive filename. I changed this at all of my project to avoid misunderstandings. And in this file there aren't routes only.

What do you think?