### PR TITLE
Upgrading browser-sync to version 2.7.6 to take advantage of the brow…

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Gulp is a "streaming build system", providing a very fast and efficient method f
 
 ##### Web Server
 
-Gulp is used here to provide a very basic node/Express web server for viewing and testing your application as you build. It serves static files from the `build/` directory, leaving routing up to AngularJS. All Gulp tasks are configured to automatically reload the server upon file changes. The application is served to `localhost:3000` once you run the `gulp` task. To take advantage of the fast live reload injection provided by browser-sync, you must load the site at the proxy address (which usually defaults to `server port + 1`, and within this boilerplate will by default be `localhost:3001`.)
+Gulp is used here to provide a very basic node/Express web server for viewing and testing your application as you build. It serves static files from the `build/` directory, leaving routing up to AngularJS. All Gulp tasks are configured to automatically reload the server upon file changes. The application is served to `localhost:3000` once you run the `gulp` task. To take advantage of the fast live reload injection provided by browser-sync, you must load the site at the proxy address (within this boilerplate will by default be `localhost:3002`.)
 
 ##### Scripts
 
@@ -120,7 +120,7 @@ Files inside `/app/views/`, on the other hand, go through a slightly more comple
 
 ##### Watching files
 
-All of the Gulp processes mentioned above are run automatically when any of the corresponding files in the `/app` directory are changed, and this is thanks to our Gulp watch tasks. Running `gulp dev` will begin watching all of these files, while also serving to `localhost:3000`, and with browser-sync proxy running at `localhost:3001` (by default).
+All of the Gulp processes mentioned above are run automatically when any of the corresponding files in the `/app` directory are changed, and this is thanks to our Gulp watch tasks. Running `gulp dev` will begin watching all of these files, while also serving to `localhost:3000`, and with browser-sync proxy running at `localhost:3002` (by default).
 
 ##### Production Task
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Gulp is a "streaming build system", providing a very fast and efficient method f
 
 ##### Web Server
 
-Gulp is used here to provide a very basic node/Express web server for viewing and testing your application as you build. It serves static files from the `build/` directory, leaving routing up to AngularJS. All Gulp tasks are configured to automatically reload the server upon file changes. The application is served to `localhost:3000` once you run the `gulp` task. To take advantage of the fast live reload injection provided by browser-sync, you must load the site at the proxy address (within this boilerplate will by default be `localhost:3002`.)
+Gulp is used here to provide a very basic node/Express web server for viewing and testing your application as you build. It serves static files from the `build/` directory, leaving routing up to AngularJS. All Gulp tasks are configured to automatically reload the server upon file changes. The application is served to `localhost:3002` once you run the `gulp` task. To take advantage of the fast live reload injection provided by browser-sync, you must load the site at the proxy address (within this boilerplate will by default be `localhost:3000`). To change the settings related to live-reload or browser-sync, you can access the UI at `localhost:3001`.
 
 ##### Scripts
 
@@ -120,7 +120,7 @@ Files inside `/app/views/`, on the other hand, go through a slightly more comple
 
 ##### Watching files
 
-All of the Gulp processes mentioned above are run automatically when any of the corresponding files in the `/app` directory are changed, and this is thanks to our Gulp watch tasks. Running `gulp dev` will begin watching all of these files, while also serving to `localhost:3000`, and with browser-sync proxy running at `localhost:3002` (by default).
+All of the Gulp processes mentioned above are run automatically when any of the corresponding files in the `/app` directory are changed, and this is thanks to our Gulp watch tasks. Running `gulp dev` will begin watching all of these files, while also serving to `localhost:3002`, and with browser-sync proxy running at `localhost:3000` (by default).
 
 ##### Production Task
 

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -2,7 +2,9 @@
 
 module.exports = {
 
-  'serverport': 3002,
+  'browserport'  : 3000,
+  'uiport'       : 3001,
+  'serverport'   : 3002,
 
   'styles': {
     'src' : 'app/styles/**/*.scss',

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 
-  'serverport': 3000,
+  'serverport': 3002,
 
   'styles': {
     'src' : 'app/styles/**/*.scss',

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -7,6 +7,10 @@ var gulp        = require('gulp');
 gulp.task('browserSync', function() {
 
   browserSync({
+  	port: config.browserport,
+  	ui: {
+    	port: config.uiport
+    }
     proxy: 'localhost:' + config.serverport
   });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "angular-ui-router": "^0.2.13",
     "babelify": "^5.0.4",
     "brfs": "^1.2.0",
-    "browser-sync": "^1.5.8",
+    "browser-sync": "^2.7.6",
     "browserify": "^5.10.0",
     "browserify-istanbul": "^0.2.0",
     "browserify-ngannotate": "^0.1.0",


### PR DESCRIPTION
…ser-sync UI server to localhost:3001. Proxy changed to :3002 with server still accessible at :3000.
Developers will now be able to change browser-sync settings such as click syncing and form submit syncing via the UI (localhost:3001) 