### PR TITLE
Fix browserSync syntax

### DIFF
--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -10,7 +10,7 @@ gulp.task('browserSync', function() {
   	port: config.browserport,
   	ui: {
     	port: config.uiport
-    }
+    },
     proxy: 'localhost:' + config.serverport
   });
 


### PR DESCRIPTION
Missing comma prevents browser sync startup when running gulp dev