### PR TITLE
Added configurable setting for logging file sizes pre and post compression during dev and prod build processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ All of the Gulp processes mentioned above are run automatically when any of the 
 
 ##### Logging File Sizes
 
-A configurable boolean, 'logsizes', is located in gulp/config.js and defaulted to false. If enabled, files that are compressed throughout the build process will have their sizes logged before and after the compression tasks. This allows you to be always be conscious of your file sizes and track the results of various optimizations.
+A configurable boolean, `logsizes`, is located in `gulp/config.js` and defaulted to `false`. If enabled, files that are compressed throughout the build process will have their sizes logged before and after the compression tasks. This allows you to be always be conscious of your file sizes and track the results of various optimizations.
 
 ##### Production Task
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Files inside `/app/views/`, on the other hand, go through a slightly more comple
 
 All of the Gulp processes mentioned above are run automatically when any of the corresponding files in the `/app` directory are changed, and this is thanks to our Gulp watch tasks. Running `gulp dev` will begin watching all of these files, while also serving to `localhost:3002`, and with browser-sync proxy running at `localhost:3000` (by default).
 
+##### Logging File Sizes
+
+A configurable boolean, 'logsizes', is located in gulp/config.js and defaulted to false. If enabled, files that are compressed throughout the build process will have their sizes logged before and after the compression tasks. This allows you to be always be conscious of your file sizes and track the results of various optimizations.
+
 ##### Production Task
 
 Just as there is the `gulp dev` task for development, there is also a `gulp prod` task for putting your project into a production-ready state. This will run each of the tasks, while also adding the image minification task discussed above. There is also an empty `gulp deploy` task that is included when running the production task. This deploy task can be fleshed out to automatically push your production-ready site to your hosting setup.

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -6,6 +6,8 @@ module.exports = {
   'uiport'       : 3001,
   'serverport'   : 3002,
 
+  'logsizes'     : false,
+
   'styles': {
     'src' : 'app/styles/**/*.scss',
     'dest': 'build/css'

--- a/gulp/tasks/gzip.js
+++ b/gulp/tasks/gzip.js
@@ -2,12 +2,16 @@
 
 var gulp   = require('gulp');
 var gzip   = require('gulp-gzip');
+var size   = require('gulp-size');
+var gulpif = require('gulp-if');
 var config = require('../config');
 
 gulp.task('gzip', function() {
 
   return gulp.src(config.gzip.src)
+  	.pipe(gulpif(config.logsizes, size({showFiles: true, title:'Pre-gzip'})))
     .pipe(gzip(config.gzip.options))
+    .pipe(gulpif(config.logsizes, size({showFiles: true, title:'Post-gzip'})))
     .pipe(gulp.dest(config.gzip.dest));
 
 });

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -4,6 +4,7 @@ var config       = require('../config');
 var gulp         = require('gulp');
 var sass         = require('gulp-sass');
 var gulpif       = require('gulp-if');
+var size         = require('gulp-size');
 var handleErrors = require('../util/handleErrors');
 var browserSync  = require('browser-sync');
 var autoprefixer = require('gulp-autoprefixer');
@@ -16,8 +17,10 @@ gulp.task('styles', function () {
       sourceMap: 'sass',
       outputStyle: global.isProd ? 'compressed' : 'nested'
     }))
+    .pipe(gulpif(config.logsizes, size({showFiles: true, title:'Pre-autoprefixer'})))
     .pipe(autoprefixer("last 2 versions", "> 1%", "ie 8"))
     .on('error', handleErrors)
+    .pipe(gulpif(config.logsizes,size({showFiles: true, title:'Post-autoprefixer'})))
     .pipe(gulp.dest(config.styles.dest))
     .pipe(gulpif(browserSync.active, browserSync.reload({ stream: true })));
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-protractor": "0.0.11",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^1.3.3",
+    "gulp-size": "^1.2.1",
     "gulp-sourcemaps": "^1.3.0",
     "gulp-streamify": "0.0.5",
     "gulp-uglify": "^1.0.1",


### PR DESCRIPTION
It's always good practice to be aware of your file sizes, especially if striving to meet performance goals. I realize not everyone cares about such things, so I made it a configurable option that's defaulted to `false`. If enabled, files that are compressed during the build process will have their sizes logged pre- and post- compression, so that you have solid numbers to use when evaluating any optimizations you may be implementing. 

Additionally, it will log the size of your CSS pre- and post- autoprefixer, so that you are aware of the impact vendor prefixes may be having on the size of your stylesheet.