### PR TITLE
Remove the extra angular declaration from tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -35,12 +35,11 @@ module.exports = function(config) {
     urlRoot: '/__karma__/',
 
     files: [
-      // 3rd-party resources
-      'node_modules/angular/angular.min.js',
-      'node_modules/angular-mocks/angular-mocks.js',
-
       // app-specific code
       'app/js/main.js',
+
+      // 3rd-party resources
+      'node_modules/angular-mocks/angular-mocks.js',
 
       // test files
       'test/unit/**/*.js'


### PR DESCRIPTION
There is the following warning when I run ```gulp unit```.
```
Chrome 44.0.2403 (Linux 0.0.0) LOG: 'WARNING: Tried to load angular more than once.'
```
Because angular is already included in the main script, I removed the one from node_modules.