### PR TITLE
Fix CSS sourcemaps for production

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -25,7 +25,7 @@ function buildScript(file) {
     debug: true,
     cache: {},
     packageCache: {},
-    fullPaths: true
+    fullPaths: !global.isProd
   }, watchify.args);
 
   if ( !global.isProd ) {

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -2,6 +2,7 @@
 
 var config       = require('../config');
 var gulp         = require('gulp');
+var sourcemaps   = require('gulp-sourcemaps');
 var sass         = require('gulp-sass');
 var handleErrors = require('../util/handleErrors');
 var browserSync  = require('browser-sync');
@@ -10,13 +11,14 @@ var autoprefixer = require('gulp-autoprefixer');
 gulp.task('styles', function () {
 
   return gulp.src(config.styles.src)
+    .pipe(sourcemaps.init())
     .pipe(sass({
-      sourceComments: global.isProd ? 'none' : 'map',
-      sourceMap: 'sass',
+      sourceComments: !global.isProd,
       outputStyle: global.isProd ? 'compressed' : 'nested'
     }))
     .pipe(autoprefixer('last 2 versions', '> 1%', 'ie 8'))
     .on('error', handleErrors)
+    .pipe(sourcemaps.write( global.isProd ? '.': null ))
     .pipe(gulp.dest(config.styles.dest))
     .pipe(browserSync.reload({ stream: true }));
 


### PR DESCRIPTION
When building for production:
- disable CSS sourceComments
- generate CSS sourcemap file: main.css.map