### PR TITLE
Added Sass include paths to gulp configuration

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -9,7 +9,8 @@ module.exports = {
   'styles': {
     'src' : 'app/styles/**/*.scss',
     'dest': 'build/css',
-    'prodSourcemap' : false
+    'prodSourcemap': false,
+    'sassIncludePaths': []
   },
 
   'scripts': {

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -17,7 +17,8 @@ gulp.task('styles', function () {
     .pipe(gulpif(createSourcemap, sourcemaps.init()))
     .pipe(sass({
       sourceComments: !global.isProd,
-      outputStyle: global.isProd ? 'compressed' : 'nested'
+      outputStyle: global.isProd ? 'compressed' : 'nested',
+      includePaths: config.styles.sassIncludePaths
     }))
     .pipe(autoprefixer('last 2 versions', '> 1%', 'ie 8'))
     .on('error', handleErrors)


### PR DESCRIPTION
Added the possibility to add Sass' `includePaths` via gulp/conf.js