### PR TITLE
Added transform options to browserify gulp task

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -36,15 +36,15 @@ function buildScript(file) {
   }
 
   var transforms = [
-    babelify,
-    debowerify,
-    ngAnnotate,
-    'brfs',
-    'bulkify'
+    { 'name':babelify, 'options': {}},
+    { 'name':debowerify, 'options': {}},
+    { 'name':ngAnnotate, 'options': {}},
+    { 'name':'brfs', 'options': {}},
+    { 'name':'bulkify', 'options': {}}
   ];
 
   transforms.forEach(function(transform) {
-    bundler.transform(transform);
+    bundler.transform(transform.name, transform.options);
   });
 
   function rebundle() {


### PR DESCRIPTION
Just throwing this out there as some users might require some tweaking for whatever reason.
This could be extended to be declared in the config and have separate options for dev/prod


here's an example if a user wanted babel to ignore scripts in the bower_components directory:
```{ 'name':babelify, 'options':{'ignore':['bower_components']}}```