### PR TITLE
Fix testing scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "scripts": {
     "pretest": "npm install",
     "test": "karma start test/karma.conf.js",
-    "preprotractor": "npm run update-webdriver",
-    "protractor": "npm run protractor test/protractor.conf.js"
+    "preprotractor": "npm install && webdriver-manager update",
+    "protractor": "protractor test/protractor.conf.js"
   }
 }

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -8,7 +8,7 @@ exports.config = {
 
   allScriptsTimeout: 11000,
 
-  baseUrl: 'http://localhost:' + gulpConfig.UIPort + '/',
+  baseUrl: 'http://localhost:' + gulpConfig.browserPort + '/',
 
   directConnect: true,
 


### PR DESCRIPTION
Testing scripts were not working at all and these changes make them work again. 

The NPM scripts were referencing themselves and falling into a loop or referencing old bin files (*update-webdriver* for example). Also the test port was all wrong for protractor, it was using the *BrowserSync* one.