### PR TITLE
Fix not being able to serve fonts and other assets using query string cache busters.

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -30,6 +30,20 @@ export default {
     dest: 'build/fonts'
   },
 
+  assetExtensions: [
+    'js',
+    'css',
+    'png',
+    'jpe?g',
+    'gif',
+    'svg',
+    'eot',
+    'otf',
+    'ttc',
+    'ttf',
+    'woff2?'
+  ],
+
   views: {
     index: 'app/index.html',
     src: 'app/views/**/*.html',

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -8,7 +8,7 @@ import gulp        from 'gulp';
 gulp.task('browserSync', function() {
 
   const DEFAULT_FILE = 'index.html';
-  const ASSET_EXTENSION_REGEX = /\b(?!\?)\.(js|css|png|jpe?g|gif|svg|eot|otf|ttc|ttf|woff2?)(?!\.)/i;
+  const ASSET_EXTENSION_REGEX = new RegExp(`\\b(?!\\?)\\.(${config.assetExtensions.join('|')})(?!\\.)`, 'i');
 
   browserSync.init({
     server: {

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -8,7 +8,7 @@ import gulp        from 'gulp';
 gulp.task('browserSync', function() {
 
   const DEFAULT_FILE = 'index.html';
-  const ASSET_EXTENSION_REGEX = new RegExp(`\\b(?!\\?)\\.(${config.assetExtensions.join('|')})(?!\\.)`, 'i');
+  const ASSET_EXTENSION_REGEX = new RegExp(`\\b(?!\\?)\\.(${config.assetExtensions.join('|')})\\b(?!\\.)`, 'i');
 
   browserSync.init({
     server: {

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -8,16 +8,15 @@ import gulp        from 'gulp';
 gulp.task('browserSync', function() {
 
   const DEFAULT_FILE = 'index.html';
-  const ASSET_EXTENSIONS = ['js', 'css', 'png', 'jpg', 'jpeg', 'gif'];
+  const ASSET_EXTENSION_REGEX = /\b(?!\?)\.(js|css|png|jpe?g|gif|svg|eot|otf|ttc|ttf|woff2?)(?!\.)/i;
 
   browserSync.init({
     server: {
       baseDir: config.buildDir,
       middleware: function(req, res, next) {
-        let fileHrefArray = url.parse(req.url).href.split('.');
-        let fileExtension = fileHrefArray[fileHrefArray.length - 1];
+        let fileHref = url.parse(req.url).href;
 
-        if ( ASSET_EXTENSIONS.indexOf(fileExtension) === -1 ) {
+        if ( !ASSET_EXTENSION_REGEX.test(fileHref) ) {
           req.url = '/' + DEFAULT_FILE;
         }
 


### PR DESCRIPTION
I was losing my sanity thinking I broke something after merging all the es6 changes lol.

one of the regressions was browserSync checking to see if an assets extensions was whitelisted in a predefined array. Unfortunately some fonts use somefont.tff?v1.2.4 as their name to prevent caching.
With the logic of splitting every occurrence of a period you'd get an array [somefont, ttf?v1, 2, 4] which would fail even if you explicitly added ttf to that array. 

I was going to add a regex to search for the extension but then I thought what's the point of this? why not just allow anything that has an extension? as everything routed through angular uses a directory structure. And anything with a '.' is probably an asset.

If someone wants to use /myapp.dev/ then I guess a regex would be needed. Thoughts?