### PR TITLE
Remove {once: true} from browserSync.stream

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -63,7 +63,7 @@ function buildScript(file) {
       }))))
       .pipe(gulpif(createSourcemap, sourcemaps.write('./')))
       .pipe(gulp.dest(config.scripts.dest))
-      .pipe(browserSync.stream({ once: true }));
+      .pipe(browserSync.stream());
   }
 
   return rebundle();

--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -10,6 +10,6 @@ gulp.task('fonts', function() {
   return gulp.src(config.fonts.src)
     .pipe(changed(config.fonts.dest)) // Ignore unchanged files
     .pipe(gulp.dest(config.fonts.dest))
-    .pipe(browserSync.stream({ once: true }));
+    .pipe(browserSync.stream());
 
 });

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -13,6 +13,6 @@ gulp.task('images', function() {
     .pipe(changed(config.images.dest)) // Ignore unchanged files
     .pipe(gulpif(global.isProd, imagemin())) // Optimize
     .pipe(gulp.dest(config.images.dest))
-    .pipe(browserSync.stream({ once: true }));
+    .pipe(browserSync.stream());
 
 });

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -27,6 +27,6 @@ gulp.task('styles', function () {
       sourcemaps.write( global.isProd ? './' : null ))
     )
     .pipe(gulp.dest(config.styles.dest))
-    .pipe(browserSync.stream();
+    .pipe(browserSync.stream());
 
 });

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -27,6 +27,6 @@ gulp.task('styles', function () {
       sourcemaps.write( global.isProd ? './' : null ))
     )
     .pipe(gulp.dest(config.styles.dest))
-    .pipe(browserSync.stream({ once: true }));
+    .pipe(browserSync.stream();
 
 });

--- a/gulp/tasks/views.js
+++ b/gulp/tasks/views.js
@@ -18,6 +18,6 @@ gulp.task('views', function() {
       standalone: true
     }))
     .pipe(gulp.dest(config.views.dest))
-    .pipe(browserSync.stream({ once: true }));
+    .pipe(browserSync.stream());
 
 });


### PR DESCRIPTION
This solves #108.

To test it you can add a bunch of CSS to the main.scss file (for example, the Bootstrap source file) and then trying to do a simple `body { background: red; }` change. When there's a lot of CSS code, the sync doesn't work too well. By removing `{ once: true }` the changes not only work, but they are smarter.