### PR TITLE
ensure all asset tasks are done before browserify

### DIFF
--- a/gulp/tasks/production.js
+++ b/gulp/tasks/production.js
@@ -4,11 +4,11 @@ import gulp        from 'gulp';
 import runSequence from 'run-sequence';
 
 gulp.task('prod', ['clean'], function(cb) {
-  
+
   cb = cb || function() {};
 
   global.isProd = true;
 
-  runSequence(['styles', 'images', 'fonts', 'views', 'browserify'], 'gzip', cb);
+  runSequence(['styles', 'images', 'fonts', 'views'], 'browserify', 'gzip', cb);
 
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs-gulp-browserify-boilerplate",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Jake Marsh <jakemmarsh@gmail.com>",
   "description": "Boilerplate using AngularJS, SASS, Gulp, and Browserify while also utilizing best practices.",
   "repository": {


### PR DESCRIPTION
#110 brought up an issue with a race condition occurring when the `views` task takes too long, meaning `browserify` was run before `templates.js` was created. This should fix that issue