### PR TITLE
Update "del" dep to latest version

### DIFF
--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -4,8 +4,8 @@ import config from '../config';
 import gulp   from 'gulp';
 import del    from 'del';
 
-gulp.task('clean', function(cb) {
+gulp.task('clean', function() {
 
-  del([config.buildDir], cb);
-
+  return del([config.buildDir]);
+  
 });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bulk-require": "^0.2.1",
     "bulkify": "^1.1.1",
     "debowerify": "^1.3.1",
-    "del": "^0.1.3",
+    "del": "^2.1.0",
     "gulp": "^3.8.8",
     "gulp-angular-templatecache": "^1.3.0",
     "gulp-autoprefixer": "^2.0.0",


### PR DESCRIPTION
Returning the promise from the task now, rather than taking in a done cb - both work as async hints to gulp