### PR TITLE
Implement CI with Travis/SauceLabs - linting + unit/e2e

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+  - "5.0"
+sudo: false
+
+script:
+    - ./node_modules/.bin/gulp lint test
+
+cache:
+    directories:
+        - node_modules
+
+addons:
+  sauce_connect: true

--- a/gulp/tasks/protractor.js
+++ b/gulp/tasks/protractor.js
@@ -1,26 +1,26 @@
 'use strict';
 
 import config       from '../config';
+import express      from 'express';
+import testServer   from '../util/testServer';
 import gulp         from 'gulp';
-import {
-  protractor,
-  webdriver,
-  webdriver_update
-} from 'gulp-protractor';
+import {protractor} from 'gulp-protractor';
 
-gulp.task('webdriver-update', webdriver_update);
-gulp.task('webdriver', webdriver);
 
-gulp.task('protractor', ['webdriver-update', 'webdriver', 'browserSync'], function(cb = function() {}) {
+gulp.task('protractor', ['prod'], function(cb) {
 
-  gulp.src('test/e2e/**/*.js').pipe(protractor({
-      configFile: config.test.protractor
-  })).on('error', (err) => {
-    // Make sure failed tests cause gulp to exit non-zero
-    throw err;
-  }).on('end', () => {
-    process.exit();
-    cb();
+  const tests = gulp.src('test/e2e/**/*.js');
+
+  testServer({
+    port: config.browserPort,
+    dir: config.buildDir
+  }).then(server => {
+    tests.pipe(protractor({
+        configFile: config.test.protractor
+    })).on('error', err => {
+      // Make sure failed tests cause gulp to exit non-zero
+      throw err;
+    }).on('end', () => server.close(cb));
   });
 
 });

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,9 +1,7 @@
-'use strict';
-
 import gulp        from 'gulp';
 import runSequence from 'run-sequence';
 
-gulp.task('test', ['browserSync'], function() {
+gulp.task('test', function() {
 
   return runSequence('unit', 'protractor');
 

--- a/gulp/tasks/unit.js
+++ b/gulp/tasks/unit.js
@@ -5,11 +5,10 @@ import path     from 'path';
 import gulp     from 'gulp';
 import {Server} from 'karma';
 
-gulp.task('unit', ['views'], function() {
+gulp.task('unit', ['views'], function(done) {
 
   new Server({
-    configFile: path.resolve(__dirname, '../..', config.test.karma),
-    singleRun: true
-  }).start();
+    configFile: path.resolve(__dirname, '../..', config.test.karma)
+  }, done).start();
 
 });

--- a/gulp/tasks/views.js
+++ b/gulp/tasks/views.js
@@ -3,21 +3,24 @@
 import config        from '../config';
 import gulp          from 'gulp';
 import browserSync   from 'browser-sync';
+import merge         from 'merge-stream';
 import templateCache from 'gulp-angular-templatecache';
 
 // Views task
 gulp.task('views', function() {
 
   // Put our index.html in the dist folder
-  gulp.src(config.views.index)
+  const indexFile = gulp.src(config.views.index)
     .pipe(gulp.dest(config.buildDir));
 
   // Process any other view files from app/views
-  return gulp.src(config.views.src)
+  const views = gulp.src(config.views.src)
     .pipe(templateCache({
       standalone: true
     }))
     .pipe(gulp.dest(config.views.dest))
     .pipe(browserSync.stream({ once: true }));
+
+  return merge(indexFile, views);
 
 });

--- a/gulp/util/testServer.js
+++ b/gulp/util/testServer.js
@@ -1,0 +1,10 @@
+import express from 'express';
+
+export default function testServer({port, dir}) {
+    const app = express();
+    app.use(express.static(dir));
+
+    return new Promise((res, rej) => {
+        const server = app.listen(port, () => res(server));
+    });
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "bulkify": "^1.1.1",
     "debowerify": "^1.3.1",
     "del": "^0.1.3",
+    "express": "^4.13.3",
     "gulp": "^3.8.8",
     "gulp-angular-templatecache": "^1.3.0",
     "gulp-autoprefixer": "^2.0.0",
@@ -62,6 +63,8 @@
     "karma-coverage": "douglasduteil/karma-coverage#next",
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.3.6",
+    "karma-sauce-launcher": "^0.3.0",
+    "merge-stream": "^1.0.0",
     "pretty-hrtime": "^0.2.2",
     "protractor": "^2.5.1",
     "run-sequence": "^0.3.6",
@@ -72,9 +75,8 @@
     "watchify": "^3.4.0"
   },
   "scripts": {
-    "pretest": "npm install",
-    "test": "karma start test/karma.conf.js",
-    "preprotractor": "npm install && webdriver-manager update",
-    "protractor": "protractor test/protractor.conf.js"
+    "test": "./node_modules/.bin/gulp test",
+    "webdriver-update": "./node_modules/.bin/webdriver-manager update",
+    "postinstall": "npm run webdriver-update"
   }
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,53 +1,77 @@
-'use strict';
+const istanbul = require('browserify-istanbul');
+const isparta  = require('isparta');
 
-var istanbul = require('browserify-istanbul');
-var isparta  = require('isparta');
+const karmaBaseConfig = {
+
+  basePath: '../',
+
+  singleRun: true,
+
+  frameworks: ['jasmine', 'browserify'],
+
+  preprocessors: {
+    'app/js/**/*.js': ['browserify', 'coverage']
+  },
+
+  browsers: ['Chrome'],
+
+  reporters: ['progress', 'coverage'],
+
+  autoWatch: true,
+
+  browserify: {
+    debug: true,
+    extensions: ['.js'],
+    transform: [
+      'babelify',
+      'browserify-ngannotate',
+      'bulkify',
+      istanbul({
+        instrumenter: isparta,
+        ignore: ['**/node_modules/**', '**/test/**']
+      })
+    ]
+  },
+
+  proxies: {
+    '/': 'http://localhost:9876/'
+  },
+
+  urlRoot: '/__karma__/',
+
+  files: [
+    // app-specific code
+    'app/js/main.js',
+
+    // 3rd-party resources
+    'node_modules/angular-mocks/angular-mocks.js',
+
+    // test files
+    'test/unit/**/*.js'
+  ]
+
+};
+
+const customLaunchers = {
+  chrome: {
+    base: 'SauceLabs',
+    browserName: 'chrome'
+  }
+};
+
+const ciAdditions = {
+  sauceLabs: {
+    testName: 'Karma Unit Tests',
+    startConnect: false,
+    build: process.env.TRAVIS_BUILD_NUMBER,
+    tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
+  },
+  browsers: Object.keys(customLaunchers),
+  customLaunchers: customLaunchers,
+  reporters: ['progress', 'coverage', 'saucelabs']
+};
 
 module.exports = function(config) {
-
-  config.set({
-
-    basePath: '../',
-    frameworks: ['jasmine', 'browserify'],
-    preprocessors: {
-      'app/js/**/*.js': ['browserify', 'coverage']
-    },
-    browsers: ['Chrome'],
-    reporters: ['progress', 'coverage'],
-
-    autoWatch: true,
-
-    browserify: {
-      debug: true,
-      extensions: ['.js'],
-      transform: [
-        'babelify',
-        'browserify-ngannotate',
-        'bulkify',
-        istanbul({
-          instrumenter: isparta,
-          ignore: ['**/node_modules/**', '**/test/**']
-        })
-      ]
-    },
-
-    proxies: {
-      '/': 'http://localhost:9876/'
-    },
-
-    urlRoot: '/__karma__/',
-
-    files: [
-      // app-specific code
-      'app/js/main.js',
-
-      // 3rd-party resources
-      'node_modules/angular-mocks/angular-mocks.js',
-
-      // test files
-      'test/unit/**/*.js'
-    ]
-
-  });
-
+  const isCI = process.env.CI;
+  config.set(isCI ? Object.assign(karmaBaseConfig, ciAdditions) : karmaBaseConfig);
 };

--- a/test/protractor.conf.js
+++ b/test/protractor.conf.js
@@ -2,20 +2,19 @@
 
 require('babel-core/register');
 
-var gulpConfig = require('../gulp/config');
+const gulpConfig = require('../gulp/config');
 
 exports.config = {
 
   allScriptsTimeout: 11000,
 
-  baseUrl: 'http://localhost:' + gulpConfig.browserPort + '/',
-
-  directConnect: true,
+  baseUrl: `http://localhost:${gulpConfig.browserPort}/`,
 
   capabilities: {
     browserName: 'chrome',
-    version: '',
-    platform: 'ANY'
+    'tunnel-identifier': process.env.TRAVIS_JOB_NUMBER,
+    build: process.env.TRAVIS_BUILD_NUMBER,
+    name: 'Protractor Tests'
   },
 
   framework: 'jasmine2',
@@ -29,6 +28,10 @@ exports.config = {
 
   specs: [
     'e2e/**/*.js'
-  ]
+  ],
+
+  sauceUser: process.env.SAUCE_USERNAME,
+
+  sauceKey: process.env.SAUCE_ACCESS_KEY
 
 };


### PR DESCRIPTION
- Implemented testing in CI
- Added small Express server for tests, instead of BrowserSync, to prevent popping (and not closing) extra browser window
- Removed "pretest" and "preprotractor", to prevent rebuilding native node addons in deps every test run
- Added "webdriver-update" to npm "post-install" hook
- Fixed unit test task to correctly signal it's async
- Return merged streams in view task, so gulp knows to wait until both are completed

[Here is this PR passing in Travis](https://travis-ci.org/DrewML/angularjs-gulp-browserify-boilerplate/builds/93727428)

[Unit Tests](https://saucelabs.com/beta/tests/8c645e4ffe194829a79fa6ae5dab3ebf/commands)
[Protractor Tests](https://saucelabs.com/beta/tests/7ee38814d5ad4bcfb4d05fd7bf12354c/commands)
