### PR TITLE
Fix sourcemaps for Browserify

### DIFF
--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -17,12 +17,16 @@ import browserSync  from 'browser-sync';
 import debowerify   from 'debowerify';
 import ngAnnotate   from 'browserify-ngannotate';
 
+function createSourcemap() {
+  return !global.isProd || config.browserify.prodSourcemap;
+}
+
 // Based on: http://blog.avisi.nl/2014/04/25/how-to-keep-a-fast-build-with-browserify-and-reactjs/
 function buildScript(file) {
-
-  var bundler = browserify({
+  
+  let bundler = browserify({
     entries: [config.sourceDir + 'js/' + file],
-    debug: true,
+    debug: createSourcemap(),
     cache: {},
     packageCache: {},
     fullPaths: !global.isProd
@@ -51,16 +55,16 @@ function buildScript(file) {
 
   function rebundle() {
     const stream = bundler.bundle();
-    const createSourcemap = global.isProd && config.browserify.prodSourcemap;
+    const sourceMapLocation = global.isProd ? './' : '';
 
     return stream.on('error', handleErrors)
       .pipe(source(file))
-      .pipe(gulpif(createSourcemap, buffer()))
-      .pipe(gulpif(createSourcemap, sourcemaps.init()))
+      .pipe(gulpif(createSourcemap(), buffer()))
+      .pipe(gulpif(createSourcemap(), sourcemaps.init({ loadMaps: true })))
       .pipe(gulpif(global.isProd, streamify(uglify({
         compress: { drop_console: true }
       }))))
-      .pipe(gulpif(createSourcemap, sourcemaps.write('./')))
+      .pipe(gulpif(createSourcemap(), sourcemaps.write(sourceMapLocation)))
       .pipe(gulp.dest(config.scripts.dest))
       .pipe(browserSync.stream({ once: true }));
   }


### PR DESCRIPTION
In master currently, `debug` is always set to `true` for Browserify. This tells Browserify to create an inline sourcemap for the bundle. However, this is additional (unnecessary) work when the prod task is running, since Uglify will strip the source maps anyway.

Further, in local development, this was actually breaking sourcemaps. The reason is because the current Browserify configuration places the sourcemap inline (`debug = true`). However, `gulp-sourcemaps` is being instructed to use an external sourcemap file. Since the internal sourcemaps exists from the initial build, the browser will not fetch the external sourcemap created by the `rebundle` function.

The following behavior should be seen after merging this PR:

## When building locally
1. Sourcemaps will always be inline
2. Sourcemaps will be generated once on first build + updated on each rebuild

## When building for Prod
1. Sourcemaps will always be external
2. Sourcemaps will only be built if the setting is enabled in `config.js`