### PR TITLE
Recursively include submodules

### DIFF
--- a/app/js/controllers/index.js
+++ b/app/js/controllers/index.js
@@ -7,10 +7,22 @@ const controllersModule = angular.module('app.controllers', []);
 
 const controllers = bulk(__dirname, ['./**/!(*index|*.spec).js']);
 
-Object.keys(controllers).forEach((key) => {
-  let item = controllers[key];
+function declare(controllerMap) {
+  Object.keys(controllerMap).forEach((key) => {
+    let item = controllerMap[key];
 
-  controllersModule.controller(item.name, item.fn);
-});
+    if (!item) {
+      return;
+    }
+
+    if (item.fn && typeof item.fn === 'function') {
+      controllersModule.controller(item.name, item.fn); 
+    } else { 
+      declare(item);
+    }
+  });
+}
+
+declare(controllers);
 
 export default controllersModule;

--- a/app/js/directives/index.js
+++ b/app/js/directives/index.js
@@ -7,10 +7,22 @@ const directivesModule = angular.module('app.directives', []);
 
 const directives = bulk(__dirname, ['./**/!(*index|*.spec).js']);
 
-Object.keys(directives).forEach((key) => {
-  let item = directives[key];
+function declare(directiveMap) {
+  Object.keys(directiveMap).forEach((key) => {
+    let item = directiveMap[key];
 
-  directivesModule.directive(item.name, item.fn);
-});
+    if (!item) {
+      return;
+    }
+
+    if (item.fn && typeof item.fn === 'function') {
+      directivesModule.directive(item.name, item.fn);
+    } else {
+      declare(item);
+    }
+  });
+}
+
+declare(directives);
 
 export default directivesModule;

--- a/app/js/filters/index.js
+++ b/app/js/filters/index.js
@@ -7,10 +7,22 @@ const filtersModule = angular.module('app.filters', []);
 
 const filters = bulk(__dirname, ['./**/!(*index|*.spec).js']);
 
-Object.keys(filters).forEach((key) => {
-  let item = filters[key];
+function declare(filterMap) {
+  Object.keys(filterMap).forEach((key) => {
+    let item = filterMap[key];
 
-  filtersModule.filter(item.name, item.fn);
-});
+    if (!item) {
+      return;
+    }
+
+    if (item.fn && typeof item.fn === 'function') {
+      filtersModule.filter(item.name, item.fn);
+    } else {
+      declare(item);
+    }
+  });
+}
+
+declare(filters);
 
 export default filtersModule;

--- a/app/js/services/index.js
+++ b/app/js/services/index.js
@@ -7,10 +7,22 @@ const servicesModule = angular.module('app.services', []);
 
 const services = bulk(__dirname, ['./**/!(*index|*.spec).js']);
 
-Object.keys(services).forEach((key) => {
-  let item = services[key];
+function declare(serviceMap) {
+  Object.keys(serviceMap).forEach((key) => {
+    let item = serviceMap[key];
 
-  servicesModule.service(item.name, item.fn);
-});
+    if (!item) {
+      return;
+    }
+    
+    if (item.fn && typeof item.fn === 'function') {
+      servicesModule.service(item.name, item.fn);
+    } else {
+      declare(item);
+    }
+  });
+}
+
+declare(services);
 
 export default servicesModule;


### PR DESCRIPTION
In `app/js/controllers/index.js`, our code as below:

```javascript
const controllers = bulk(__dirname, ['./**/!(*index|*.spec).js']);

Object.keys(controllers).forEach((key) => {
  let item = controllers[key];

  controllersModule.controller(item.name, item.fn);
});

```

If we have a file structure looks like below:
```
-- controllers
  -- example.js
  -- folder
    -- another.js
```

We got a `controllers` object after bulked:

```json
{
  "example": {
    "fn": "ExampleCtrl()",
    "name": "ExampleCtrl"
  },
  "folder": {
    "another": {
      "fn": "AnotherCtrl()",
      "name": "AnotherCtrl"
    }
  }
}
```

Unfortunately, `AnotherCtrl` did not declare as a controller because it's lying under a folder. `services`/`filters`/`directives` have the same problem, so I create this PR to solve it.