### PR TITLE
Fixed gulp dev issue at first run

### DIFF
--- a/gulp/tasks/development.js
+++ b/gulp/tasks/development.js
@@ -7,6 +7,6 @@ gulp.task('dev', ['clean'], function(cb) {
 
   global.isProd = false;
 
-  runSequence(['styles', 'images', 'fonts', 'views', 'browserify'], 'watch', cb);
+  runSequence(['styles', 'images', 'fonts', 'views'], 'browserify', 'watch', cb);
 
 });


### PR DESCRIPTION
When view is too large and browserify runs faster than that.
template.js wouldn't be available for browserify to import i
So, gulp dev would get compile error that template.js not found.
browserify should be run after all other dependencies are satisfied.