### PR TITLE
Fix autoprefixer step

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -21,7 +21,9 @@ gulp.task('styles', function () {
       includePaths: config.styles.sassIncludePaths
     }))
     .on('error', handleErrors)
-    .pipe(autoprefixer('last 2 versions', '> 1%', 'ie 8'))
+    .pipe(autoprefixer({
+      browsers: ['last 2 versions', '> 1%', 'ie 8']
+    }))
     .pipe(gulpif(
       createSourcemap,
       sourcemaps.write( global.isProd ? './' : null ))


### PR DESCRIPTION
The autoprefixer plugin is only taking into account the first argument ('last 2 versions')

The correct syntax should be:
`autoprefixer({
  browsers: [ ... ]
});
`
