### PR TITLE
Serve *.js.map files as assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs-gulp-browserify-boilerplate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Jake Marsh <jakemmarsh@gmail.com>",
   "description": "Boilerplate using AngularJS, SASS, Gulp, and Browserify while also utilizing best practices.",
   "repository": {


### PR DESCRIPTION
Enables SourceMaps to work correctly (for example in Chrome developer tools).