### PR TITLE
Removed redundant 'use strict' since it comes standard with es6

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 export default {
 
   browserPort: 3000,

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import fs          from 'fs';
 import gulp        from 'gulp';
 import onlyScripts from './util/scriptFilter';

--- a/gulp/tasks/browserSync.js
+++ b/gulp/tasks/browserSync.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config      from '../config';
 import url         from 'url';
 import browserSync from 'browser-sync';

--- a/gulp/tasks/browserify.js
+++ b/gulp/tasks/browserify.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import gulp         from 'gulp';
 import gulpif       from 'gulp-if';
 import source       from 'vinyl-source-stream';

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config from '../config';
 import gulp   from 'gulp';
 import del    from 'del';

--- a/gulp/tasks/deploy.js
+++ b/gulp/tasks/deploy.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import gulp from 'gulp';
 
 gulp.task('deploy', ['prod'], function() {

--- a/gulp/tasks/development.js
+++ b/gulp/tasks/development.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import gulp        from 'gulp';
 import runSequence from 'run-sequence';
 

--- a/gulp/tasks/eslint.js
+++ b/gulp/tasks/eslint.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config from '../config';
 import gulp   from 'gulp';
 import eslint from 'gulp-eslint';

--- a/gulp/tasks/fonts.js
+++ b/gulp/tasks/fonts.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config      from '../config';
 import changed     from 'gulp-changed';
 import gulp        from 'gulp';

--- a/gulp/tasks/gzip.js
+++ b/gulp/tasks/gzip.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config from '../config';
 import gulp   from 'gulp';
 import gzip   from 'gulp-gzip';

--- a/gulp/tasks/images.js
+++ b/gulp/tasks/images.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config      from '../config';
 import changed     from 'gulp-changed';
 import gulp        from 'gulp';

--- a/gulp/tasks/production.js
+++ b/gulp/tasks/production.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import gulp        from 'gulp';
 import runSequence from 'run-sequence';
 

--- a/gulp/tasks/protractor.js
+++ b/gulp/tasks/protractor.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config     from '../config';
 import testServer from '../util/testServer';
 import gulp       from 'gulp';

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config       from '../config';
 import gulp         from 'gulp';
 import gulpif       from 'gulp-if';

--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import gulp        from 'gulp';
 import runSequence from 'run-sequence';
 

--- a/gulp/tasks/unit.js
+++ b/gulp/tasks/unit.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config   from '../config';
 import path     from 'path';
 import gulp     from 'gulp';

--- a/gulp/tasks/views.js
+++ b/gulp/tasks/views.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config        from '../config';
 import gulp          from 'gulp';
 import merge         from 'merge-stream';

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import config from '../config';
 import gulp   from 'gulp';
 

--- a/gulp/util/bundleLogger.js
+++ b/gulp/util/bundleLogger.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import gutil        from 'gulp-util';
 import prettyHrtime from 'pretty-hrtime';
 

--- a/gulp/util/handleErrors.js
+++ b/gulp/util/handleErrors.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import gutil  from 'gulp-util';
 import notify from 'gulp-notify';
 

--- a/gulp/util/scriptFilter.js
+++ b/gulp/util/scriptFilter.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import path from 'path';
 
 // Filters out non .js files. Prevents

--- a/gulp/util/testServer.js
+++ b/gulp/util/testServer.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import express from 'express';
 
 export default function testServer({port, dir}) {

--- a/test/e2e/example_spec.js
+++ b/test/e2e/example_spec.js
@@ -1,7 +1,5 @@
 /*global browser, by */
 
-'use strict';
-
 describe('E2E: Example', function() {
 
   beforeEach(function() {

--- a/test/e2e/routes_spec.js
+++ b/test/e2e/routes_spec.js
@@ -1,7 +1,5 @@
 /*global browser */
 
-'use strict';
-
 describe('E2E: Routes', function() {
 
   it('should have a working home route', function() {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const istanbul = require('browserify-istanbul');
 const isparta  = require('isparta');
 

--- a/test/unit/constants_spec.js
+++ b/test/unit/constants_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('Unit: Constants', function() {
 
   let constants;

--- a/test/unit/controllers/example_spec.js
+++ b/test/unit/controllers/example_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('Unit: ExampleCtrl', function() {
 
   let ctrl;

--- a/test/unit/directives/example_spec.js
+++ b/test/unit/directives/example_spec.js
@@ -1,7 +1,5 @@
 /* global module */
 
-'use strict';
-
 describe('Unit: ExampleDirective', function() {
 
   let element;

--- a/test/unit/filters/example_spec.js
+++ b/test/unit/filters/example_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('Unit: ExampleFilter', function() {
 
   let $filter;

--- a/test/unit/services/example_spec.js
+++ b/test/unit/services/example_spec.js
@@ -1,5 +1,3 @@
-'use strict';
-
 describe('Unit: ExampleService', function() {
 
   let http, service;


### PR DESCRIPTION
Removed useless "use strict" from tasks and tests, [es6 has strict mode enabled by default](http://stackoverflow.com/a/31685340/3741361).

I tested it by declaring a variable globally with no prefix and it behaves as it would in strict mode.