### PR TITLE
Use https/tarball for karma-coverage dependancy instead of git

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "karma": "^1.3.0",
     "karma-browserify": "^5.0.2",
     "karma-chrome-launcher": "^2.0.0",
-    "karma-coverage": "douglasduteil/karma-coverage#next",
+    "karma-coverage": "https://github.com/douglasduteil/karma-coverage/tarball/next",
     "karma-firefox-launcher": "^1.0.0",
     "karma-jasmine": "^1.0.2",
     "karma-sauce-launcher": "^1.0.0",


### PR DESCRIPTION
For portability, we should use the HTTPS protocol rather than Git, since not all machines have Git installed globally. 